### PR TITLE
fix gradle task dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 
-version = "0.3.0"
+version = "0.3.1"
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8"
@@ -75,3 +75,7 @@ jacocoTestReport {
         xml.enabled true
     }
 }
+
+jacocoTestReport.dependsOn test
+build.dependsOn jfxNative
+build.dependsOn jacocoTestReport

--- a/shippable.yml
+++ b/shippable.yml
@@ -19,7 +19,7 @@ build:
     - mkdir -p shippable/codecoverage/target/site/jacoco
     - rm -rf build
     - gradle wrapper
-    - ./gradlew clean test jacocoTestReport build
+    - ./gradlew clean build
     - cp build/test-results/test/*.xml shippable/testresults
     - cp build/reports/jacoco/test/jacocoTestReport.xml shippable/codecoverage
     - cp -r build/jacoco/test.exec shippable/codecoverage/target/site/jacoco


### PR DESCRIPTION
fix gradle dependencies so that jfxNative will run as part of the build
update revision version